### PR TITLE
feat: add configurable layout option for Spotlight UI

### DIFF
--- a/config/scramble.php
+++ b/config/scramble.php
@@ -65,6 +65,14 @@ return [
          * Use to fetch the credential policy for the Try It feature. Options are: omit, include (default), and same-origin
          */
         'try_it_credentials_policy' => 'include',
+
+		/*
+		 * There are three layouts for Elements:
+		 * - sidebar - (default) Three-column design with a sidebar that can be resized.
+		 * - responsive - Like sidebar, except at small screen sizes it collapses the sidebar into a drawer that can be toggled open.
+		 * - stacked - Everything in a single column, making integrations with existing websites that have their own sidebar or other columns already.
+		 */
+		'layout' => 'sidebar',
     ],
 
     /*

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -56,6 +56,7 @@
     @if($config->get('ui.hide_try_it')) hideTryIt="true" @endif
     @if($config->get('ui.hide_schemas')) hideSchemas="true" @endif
     logo="{{ $config->get('ui.logo') }}"
+    @if($config->get('ui.layout')) layout="{{ $config->get('ui.layout') }}" @endif
 />
 <script>
     (async () => {


### PR DESCRIPTION
- Introduce new config key `scramble.ui.layout` to allow users to select from different Spotlight layouts supported by Stoplight Elements.
- Pass the layout configuration to the Spotlight component during initialization.
- Default to the sidebar layout if no custom layout is provided.